### PR TITLE
[UI 추가] GNB 추가 및 각 페이지에 적용

### DIFF
--- a/src/components/Layout/Layout.tsx
+++ b/src/components/Layout/Layout.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import Menu from "../Menu";
+import { Box } from "@mui/material";
 
 interface LayoutProps {
   children: React.ReactNode;
@@ -7,10 +8,22 @@ interface LayoutProps {
 
 const Layout = ({ children }: LayoutProps) => {
   return (
-    <div>
+    <Box
+      sx={{
+        display: "flex",
+        flexDirection: "row",
+        width: "100vw",
+      }}
+    >
       <Menu />
-      {children}
-    </div>
+      <Box
+        sx={{
+          width: "calc(100vw - 300px)",
+        }}
+      >
+        {children}
+      </Box>
+    </Box>
   );
 };
 

--- a/src/components/Layout/Layout.tsx
+++ b/src/components/Layout/Layout.tsx
@@ -1,0 +1,17 @@
+import React from "react";
+import Menu from "../Menu";
+
+interface LayoutProps {
+  children: React.ReactNode;
+}
+
+const Layout = ({ children }: LayoutProps) => {
+  return (
+    <div>
+      <Menu />
+      {children}
+    </div>
+  );
+};
+
+export default Layout;

--- a/src/components/Layout/index.tsx
+++ b/src/components/Layout/index.tsx
@@ -1,0 +1,1 @@
+export { default } from "./Layout";

--- a/src/components/Menu/Menu.tsx
+++ b/src/components/Menu/Menu.tsx
@@ -1,15 +1,90 @@
 import React from "react";
-import { useLocation, useNavigate } from "react-router-dom";
+import { useNavigate } from "react-router-dom";
+import {
+  List,
+  ListItem,
+  ListItemButton,
+  ListItemText,
+  Divider,
+} from "@mui/material";
+import MenuList from "./MenuList";
 
 const Menu = () => {
-  const pathNames = useLocation();
+  // const pathNames = useLocation();
   const navigate = useNavigate();
 
   return (
     <div>
-      <div onClick={() => navigate("/")}>Dashboard</div>
-      <div onClick={() => navigate("/system")}>System</div>
-      <div onClick={() => navigate("/dailybook")}>Dailybook</div>
+      <List sx={{ width: "100%", maxWidth: 300 }}>
+        <ListItem disablePadding>
+          <ListItemButton component="a" onClick={() => navigate("/")}>
+            <ListItemText primary="Dashboard" />
+          </ListItemButton>
+        </ListItem>
+        <Divider />
+        <ListItem disablePadding>
+          <ListItemButton component="a" onClick={() => navigate("/#")}>
+            <ListItemText primary="System" />
+          </ListItemButton>
+        </ListItem>
+        <MenuList
+          data={[
+            { path: "/", label: "SMS/LMS 발송 (운영자용)" },
+            { path: "/", label: "Push Noti 발송 (개발자용)" },
+          ]}
+          menu={"공통기능"}
+        />
+        <MenuList
+          data={[
+            { path: "/", label: "공통 코드" },
+            { path: "/", label: "HTTP 요청 응답 이력" },
+            { path: "/", label: "스케줄러 관리" },
+          ]}
+          menu={"시스템 데이터"}
+        />
+        <Divider />
+        <ListItem disablePadding>
+          <ListItemButton component="a" onClick={() => navigate("/#")}>
+            <ListItemText primary="Dailybook" />
+          </ListItemButton>
+        </ListItem>
+        <MenuList
+          data={[
+            { path: "/", label: "시설장 요청 관리" },
+            { path: "/", label: "시설직원 요청 관리" },
+            { path: "/", label: "보호자 수기 가입" },
+          ]}
+          menu={"가입 승인 관리"}
+        />
+        <MenuList
+          data={[
+            { path: "/", label: "전체 게시글 통계" },
+            { path: "/", label: "공지사항" },
+            { path: "/", label: "알림장" },
+            { path: "/", label: "알림장 조회율" },
+          ]}
+          menu={"데이터 관리"}
+        />
+        <MenuList
+          data={[
+            { path: "/", label: "고객의 소리 관리" },
+            { path: "/", label: "사용자 관리" },
+            { path: "/", label: "사용자 스위칭" },
+            { path: "/", label: "시설 관리" },
+            { path: "/", label: "시설 상담" },
+            { path: "/", label: "시설 상담 이력" },
+          ]}
+          menu={"CRM 관리"}
+        />
+        <MenuList
+          data={[
+            { path: "/", label: "홈 배너 관리" },
+            { path: "/", label: "데일리북 소식 관리" },
+          ]}
+          menu={"앱 관리"}
+        />
+        <Divider />
+      </List>
     </div>
   );
 };

--- a/src/components/Menu/Menu.tsx
+++ b/src/components/Menu/Menu.tsx
@@ -1,0 +1,17 @@
+import React from "react";
+import { useLocation, useNavigate } from "react-router-dom";
+
+const Menu = () => {
+  const pathNames = useLocation();
+  const navigate = useNavigate();
+
+  return (
+    <div>
+      <div onClick={() => navigate("/")}>Dashboard</div>
+      <div onClick={() => navigate("/system")}>System</div>
+      <div onClick={() => navigate("/dailybook")}>Dailybook</div>
+    </div>
+  );
+};
+
+export default Menu;

--- a/src/components/Menu/Menu.tsx
+++ b/src/components/Menu/Menu.tsx
@@ -6,6 +6,7 @@ import {
   ListItemButton,
   ListItemText,
   Divider,
+  Box,
 } from "@mui/material";
 import MenuList from "./MenuList";
 
@@ -14,7 +15,7 @@ const Menu = () => {
   const navigate = useNavigate();
 
   return (
-    <div>
+    <Box sx={{ height: "100vh", overflow: "auto" }}>
       <List sx={{ width: "100%", maxWidth: 300 }}>
         <ListItem disablePadding>
           <ListItemButton component="a" onClick={() => navigate("/")}>
@@ -85,7 +86,7 @@ const Menu = () => {
         />
         <Divider />
       </List>
-    </div>
+    </Box>
   );
 };
 

--- a/src/components/Menu/MenuList.tsx
+++ b/src/components/Menu/MenuList.tsx
@@ -1,0 +1,111 @@
+import * as React from "react";
+import Box from "@mui/material/Box";
+import { styled, ThemeProvider, createTheme } from "@mui/material/styles";
+import List from "@mui/material/List";
+import ListItemButton from "@mui/material/ListItemButton";
+import ListItemText from "@mui/material/ListItemText";
+import Paper from "@mui/material/Paper";
+import KeyboardArrowDown from "@mui/icons-material/KeyboardArrowDown";
+
+const FireNav = styled(List)<{ component?: React.ElementType }>({
+  "& .MuiListItemButton-root": {
+    paddingLeft: 16,
+    paddingRight: 16,
+    paddingTop: 12,
+    paddingBottom: 12,
+  },
+  "& .MuiListItemIcon-root": {
+    minWidth: 0,
+    marginRight: 16,
+  },
+  "& .MuiSvgIcon-root": {
+    fontSize: 20,
+  },
+});
+
+interface MenuListProps {
+  data: { path: string; label: string }[] | null;
+  menu: string;
+}
+const MenuList = ({ data, menu }: MenuListProps) => {
+  const [open, setOpen] = React.useState(false);
+  return (
+    <Box sx={{ display: "flex" }}>
+      <ThemeProvider
+        theme={createTheme({
+          components: {
+            MuiListItemButton: {
+              defaultProps: {
+                disableTouchRipple: true,
+              },
+            },
+          },
+          palette: {
+            mode: "light",
+            primary: { main: "rgb(102, 157, 246)" },
+          },
+        })}
+      >
+        <Paper elevation={0}>
+          <FireNav component="nav" disablePadding>
+            <Box
+              sx={{
+                bgcolor: open ? "rgba(0, 0, 0, 0.02)" : null,
+                pb: 0,
+                width: 300,
+              }}
+            >
+              <ListItemButton
+                alignItems="flex-start"
+                onClick={() => (data ? setOpen(!open) : null)}
+                sx={{
+                  px: 3,
+                  pt: 2.5,
+                  pb: 2.5,
+                  "& svg": { opacity: data ? 1 : 0 },
+                }}
+              >
+                <ListItemText
+                  primary={menu}
+                  primaryTypographyProps={{
+                    fontSize: 15,
+                    fontWeight: "bold",
+                    lineHeight: "20px",
+                    mb: "2px",
+                  }}
+                  sx={{ my: 0 }}
+                />
+                <KeyboardArrowDown
+                  sx={{
+                    mr: -1,
+                    opacity: 0,
+                    transform: open ? "rotate(-180deg)" : "rotate(0)",
+                    transition: "0.2s",
+                  }}
+                />
+              </ListItemButton>
+              {open &&
+                data &&
+                data.map((item) => (
+                  <ListItemButton
+                    key={item.label}
+                    sx={{ py: 0, minHeight: 48, color: "rgba(0,0,0)" }}
+                  >
+                    <ListItemText
+                      primary={item.label}
+                      primaryTypographyProps={{
+                        fontSize: 14,
+                        fontWeight: "medium",
+                      }}
+                    />
+                  </ListItemButton>
+                ))}
+            </Box>
+          </FireNav>
+        </Paper>
+      </ThemeProvider>
+    </Box>
+  );
+};
+
+export default MenuList;

--- a/src/components/Menu/index.tsx
+++ b/src/components/Menu/index.tsx
@@ -1,0 +1,1 @@
+export { default } from "./Menu";

--- a/src/pages/Dailybook/Dailybook.tsx
+++ b/src/pages/Dailybook/Dailybook.tsx
@@ -1,7 +1,12 @@
 import React from "react";
+import Layout from "~/components/Layout";
 
 const Dailybook = () => {
-  return <h1>Hello Dailybook!</h1>;
+  return (
+    <Layout>
+      <div>Dailybook Here!</div>
+    </Layout>
+  );
 };
 
 export default Dailybook;

--- a/src/pages/Home/Home.tsx
+++ b/src/pages/Home/Home.tsx
@@ -1,8 +1,40 @@
 import React from "react";
+import Layout from "~/components/Layout";
 
 // root path ::  dashboard
 const Home = () => {
-  return <h1>Dashboard Here!</h1>;
+  return (
+    <Layout>
+      <div>
+        <div>
+          <div>데일리북 사용자 통계</div>
+          <div>데일리북 게시글 통계</div>
+          <div>데일리북 승인 대기 통계</div>
+        </div>
+        <div>
+          <div>데일리북 사용자 통계</div>
+          <div>데일리북 게시글 Top 7</div>
+          <div>데일리북 가입자 통계</div>
+        </div>
+        <div>
+          <div>데일리북 월별 알림장 조회율</div>
+          <div>데일리북 일별 알림장 조회율</div>
+        </div>
+        <div>
+          <div>월별 시설장 가입</div>
+          <div>월별 사용자 가입</div>
+          <div>월별 알림장 수</div>
+          <div>월별 첨부파일 수</div>
+        </div>
+        <div>
+          <div>월별 시설장 가입 누적</div>
+          <div>월별 사용자 가입 누적</div>
+          <div>월별 알림장 수 누적</div>
+          <div>월별 첨부파일 수 누적</div>
+        </div>
+      </div>
+    </Layout>
+  );
 };
 
 export default Home;

--- a/src/pages/System/System.tsx
+++ b/src/pages/System/System.tsx
@@ -1,7 +1,12 @@
 import React from "react";
+import Layout from "~/components/Layout";
 
 const System = () => {
-  return <h1>Hello System!</h1>;
+  return (
+    <Layout>
+      <div>System Here!</div>
+    </Layout>
+  );
 };
 
 export default System;


### PR DESCRIPTION
## 작업 내용 ⚒️

- GNB를 추가하였습니다.
- Layout, Menu, MenuList 컴포넌트를 추가했습니다.
- components 폴더가 추가됐습니다.

## 리뷰어 참고 사항 🤔

- GNB가 추가로 수정될 예정입니다. 공유용으로 전체 레이아웃만 참고하여 개발 진행하면 될 것 같습니다.
- 좌 : GNB width 300px 기존 어드민 참고, 우 : 페이지 width calc(100vw - 300px)
- mui 커스터마이징이 어려워서 기존 admin 에서 GNB UI가 변경되었습니다. (1 depth 오픈한 상태로 메뉴 구현)
- 추가 작업이 있을 예정이니 브랜치는 유지 부탁드립니다.

### 참고 자료 🚀

- (기획서, 아사나 task, 슬랙 등 관련된 문서를 공유해 주세요)

